### PR TITLE
Main menu

### DIFF
--- a/Scenes/Editor.tscn
+++ b/Scenes/Editor.tscn
@@ -44,7 +44,7 @@ text = "Beat"
 [node name="FileDialog" type="FileDialog" parent="."]
 title = "Open a File or Directory"
 position = Vector2i(710, 310)
-size = Vector2i(682, 382)
+size = Vector2i(836, 442)
 min_size = Vector2i(500, 300)
 ok_button_text = "Open"
 file_mode = 3

--- a/Scenes/LevelSelect.tscn
+++ b/Scenes/LevelSelect.tscn
@@ -1,30 +1,30 @@
 [gd_scene load_steps=3 format=3 uid="uid://cu36g11358jm2"]
 
-[ext_resource type="Script" path="res://Scripts/Controller.gd" id="1_lmrb1"]
-[ext_resource type="Texture2D" uid="uid://bkghs5av377cf" path="res://Assets/brainlet.png" id="2_5xu3x"]
+[ext_resource type="Script" path="res://Scripts/Controller.gd" id="1_4m5vy"]
+[ext_resource type="Texture2D" uid="uid://bkghs5av377cf" path="res://Assets/brainlet.png" id="2_qvbfk"]
 
 [node name="Node2D" type="Node2D"]
-script = ExtResource("1_lmrb1")
+script = ExtResource("1_4m5vy")
 
 [node name="Brainlet" type="Sprite2D" parent="."]
 position = Vector2(960, 540)
-texture = ExtResource("2_5xu3x")
+texture = ExtResource("2_qvbfk")
 
 [node name="SongInfo" type="Node2D" parent="."]
 position = Vector2(-65, 0)
 
 [node name="BOX" type="ColorRect" parent="SongInfo"]
-offset_left = 1205.0
+offset_left = 1209.0
 offset_top = 200.0
 offset_right = 1905.0
 offset_bottom = 750.0
 color = Color(0.137255, 0.137255, 0.137255, 0.537255)
 
 [node name="InfoTitle" type="Label" parent="SongInfo"]
-offset_left = 1205.0
+offset_left = 1209.0
 offset_top = 100.0
 offset_right = 1855.0
-offset_bottom = 200.0
+offset_bottom = 192.0
 theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/shadow_offset_x = 7
@@ -49,23 +49,23 @@ vertical_alignment = 1
 justification_flags = 162
 
 [node name="PlayButton" type="Button" parent="SongInfo"]
-offset_left = 1205.0
-offset_top = 775.0
+offset_left = 1209.0
+offset_top = 768.0
 offset_right = 1905.0
-offset_bottom = 875.0
+offset_bottom = 896.0
 tooltip_text = "Play the selected song."
-theme_override_font_sizes/font_size = 75
+theme_override_font_sizes/font_size = 72
 action_mode = 0
 text = "Play"
 
 [node name="X" type="Button" parent="SongInfo"]
 offset_left = 1830.0
-offset_top = 112.5
+offset_top = 112.0
 offset_right = 1905.0
-offset_bottom = 203.5
+offset_bottom = 212.0
 scale = Vector2(1, 0.8)
 tooltip_text = "Close the detailed song menu."
-theme_override_font_sizes/font_size = 60
+theme_override_font_sizes/font_size = 58
 action_mode = 0
 text = "X"
 
@@ -184,25 +184,24 @@ clip_text = true
 text_overrun_behavior = 3
 
 [node name="Settings" type="Button" parent="."]
-offset_left = 1515.0
-offset_top = 900.0
+offset_left = 1520.0
+offset_top = 904.0
 offset_right = 1840.0
-offset_bottom = 1000.0
+offset_bottom = 1024.0
 tooltip_text = "seting menu :3"
-theme_override_font_sizes/font_size = 75
+theme_override_font_sizes/font_size = 72
 action_mode = 0
 text = "Settings"
 
 [node name="OtherButton" type="Button" parent="."]
-visible = false
-offset_left = 1140.0
-offset_top = 900.0
-offset_right = 1465.0
-offset_bottom = 1000.0
+offset_left = 1144.0
+offset_top = 904.0
+offset_right = 1504.0
+offset_bottom = 1024.0
 tooltip_text = "seting menu :3"
-theme_override_font_sizes/font_size = 60
+theme_override_font_sizes/font_size = 72
 action_mode = 0
-text = "Sumthin"
+text = "Back"
 
 [node name="SongSelect" type="Node2D" parent="."]
 position = Vector2(-25, 0)
@@ -238,10 +237,10 @@ custom_minimum_size = Vector2(1000, 800)
 layout_mode = 2
 
 [node name="MenuTitle" type="Label" parent="SongSelect"]
-offset_left = 100.0
-offset_top = 100.0
-offset_right = 1100.0
-offset_bottom = 200.0
+offset_left = 97.0
+offset_top = 80.0
+offset_right = 1097.0
+offset_bottom = 192.0
 theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/shadow_offset_x = 10
@@ -255,4 +254,4 @@ horizontal_alignment = 1
 [connection signal="pressed" from="SongInfo/PlayButton" to="." method="_level"]
 [connection signal="pressed" from="SongInfo/X" to="." method="_closeLevelDetails"]
 [connection signal="pressed" from="Settings" to="." method="_settings"]
-[connection signal="pressed" from="OtherButton" to="." method="_settings"]
+[connection signal="pressed" from="OtherButton" to="." method="_back"]

--- a/Scenes/MainMenu.tscn
+++ b/Scenes/MainMenu.tscn
@@ -1,0 +1,81 @@
+[gd_scene load_steps=4 format=3 uid="uid://b1ehyx3ks0y6f"]
+
+[ext_resource type="Script" path="res://Scripts/MainMenu.gd" id="1_p4f3a"]
+[ext_resource type="Texture2D" uid="uid://bkghs5av377cf" path="res://Assets/brainlet.png" id="2_oj34d"]
+[ext_resource type="FontFile" uid="uid://dp8yov8u64sah" path="res://Assets/VT323-Regular.ttf" id="3_h6qxa"]
+
+[node name="MainMenu" type="Node2D"]
+script = ExtResource("1_p4f3a")
+
+[node name="Brainlet" type="Sprite2D" parent="."]
+position = Vector2(960, 540)
+texture = ExtResource("2_oj34d")
+
+[node name="Title" type="Node2D" parent="."]
+
+[node name="TitleText" type="Label" parent="Title"]
+offset_right = 1920.0
+offset_bottom = 357.0
+theme_override_colors/font_color = Color(0.913725, 0, 0.203922, 1)
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/shadow_offset_x = 10
+theme_override_constants/shadow_offset_y = 10
+theme_override_constants/outline_size = 10
+theme_override_constants/shadow_outline_size = 10
+theme_override_fonts/font = ExtResource("3_h6qxa")
+theme_override_font_sizes/font_size = 244
+text = "Beats Of Mind"
+horizontal_alignment = 1
+vertical_alignment = 1
+uppercase = true
+
+[node name="MenuButtons" type="Node2D" parent="."]
+
+[node name="StoryMode" type="Button" parent="MenuButtons"]
+offset_left = 768.0
+offset_top = 448.0
+offset_right = 1152.0
+offset_bottom = 544.0
+theme_override_fonts/font = ExtResource("3_h6qxa")
+theme_override_font_sizes/font_size = 75
+text = "Story Mode"
+
+[node name="FreePlay" type="Button" parent="MenuButtons"]
+offset_left = 768.0
+offset_top = 608.0
+offset_right = 1152.0
+offset_bottom = 704.0
+theme_override_fonts/font = ExtResource("3_h6qxa")
+theme_override_font_sizes/font_size = 75
+text = "Free Play"
+
+[node name="ChartEditor" type="Button" parent="MenuButtons"]
+offset_left = 768.0
+offset_top = 768.0
+offset_right = 1152.0
+offset_bottom = 864.0
+theme_override_fonts/font = ExtResource("3_h6qxa")
+theme_override_font_sizes/font_size = 75
+text = "Chart Editor"
+
+[node name="Settings" type="Button" parent="MenuButtons"]
+anchors_preset = 13
+anchor_left = 0.5
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = 768.0
+offset_top = 928.0
+offset_right = 1152.0
+offset_bottom = 1023.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 4
+theme_override_fonts/font = ExtResource("3_h6qxa")
+theme_override_font_sizes/font_size = 75
+action_mode = 0
+text = "Settings"
+icon_alignment = 1
+
+[connection signal="pressed" from="MenuButtons/FreePlay" to="." method="_freePlay"]
+[connection signal="pressed" from="MenuButtons/Settings" to="." method="_settings"]

--- a/Scenes/NoteHole.tscn
+++ b/Scenes/NoteHole.tscn
@@ -11,7 +11,6 @@ script = ExtResource("1_jpd0x")
 [node name="noteholesprite" type="Sprite2D" parent="."]
 
 [node name="Area2D" type="Area2D" parent="."]
-scale = Vector2(1, 1)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
 position = Vector2(-5, 45)

--- a/Scenes/PlayGame.tscn
+++ b/Scenes/PlayGame.tscn
@@ -240,6 +240,7 @@ offset_right = 40.0
 offset_bottom = 40.0
 
 [node name="Value" type="Label" parent="FinalScore/Perfect"]
+layout_mode = 0
 offset_left = 960.0
 offset_top = 450.0
 offset_right = 1210.0
@@ -255,6 +256,7 @@ text = "0"
 horizontal_alignment = 2
 
 [node name="Text" type="Label" parent="FinalScore/Perfect"]
+layout_mode = 0
 offset_left = 400.0
 offset_top = 425.0
 offset_right = 900.0
@@ -278,6 +280,7 @@ offset_right = 40.0
 offset_bottom = 40.0
 
 [node name="Text" type="Label" parent="FinalScore/Good"]
+layout_mode = 0
 offset_left = 400.0
 offset_top = 535.0
 offset_right = 900.0
@@ -294,6 +297,7 @@ horizontal_alignment = 2
 vertical_alignment = 1
 
 [node name="Value" type="Label" parent="FinalScore/Good"]
+layout_mode = 0
 offset_left = 960.0
 offset_top = 560.0
 offset_right = 1210.0
@@ -316,6 +320,7 @@ offset_right = 40.0
 offset_bottom = 40.0
 
 [node name="Value" type="Label" parent="FinalScore/Okay"]
+layout_mode = 0
 offset_left = 960.0
 offset_top = 670.0
 offset_right = 1210.0
@@ -331,6 +336,7 @@ text = "0"
 horizontal_alignment = 2
 
 [node name="Text" type="Label" parent="FinalScore/Okay"]
+layout_mode = 0
 offset_left = 400.0
 offset_top = 645.0
 offset_right = 900.0
@@ -354,6 +360,7 @@ offset_right = 40.0
 offset_bottom = 40.0
 
 [node name="Value" type="Label" parent="FinalScore/Miss"]
+layout_mode = 0
 offset_left = 960.0
 offset_top = 780.0
 offset_right = 1210.0
@@ -369,6 +376,7 @@ text = "0"
 horizontal_alignment = 2
 
 [node name="Text" type="Label" parent="FinalScore/Miss"]
+layout_mode = 0
 offset_left = 400.0
 offset_top = 755.0
 offset_right = 900.0

--- a/Scenes/SceneTransitions.tscn
+++ b/Scenes/SceneTransitions.tscn
@@ -1,0 +1,59 @@
+[gd_scene load_steps=5 format=3 uid="uid://ckeffft582jid"]
+
+[ext_resource type="Script" path="res://Scripts/SceneTransitions.gd" id="1_s3d0g"]
+
+[sub_resource type="Animation" id="Animation_newds"]
+resource_name = "RESET"
+length = 0.01
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("transition:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 0)]
+}
+
+[sub_resource type="Animation" id="Animation_kkqr5"]
+resource_name = "disolve"
+length = 0.3
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("transition:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.3),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_lyphs"]
+_data = {
+"RESET": SubResource("Animation_newds"),
+"disolve": SubResource("Animation_kkqr5")
+}
+
+[node name="SceneTransitions" type="CanvasLayer"]
+script = ExtResource("1_s3d0g")
+
+[node name="transition" type="ColorRect" parent="."]
+modulate = Color(1, 1, 1, 0)
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+color = Color(0.333333, 0, 0, 1)
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_lyphs")
+}

--- a/Scripts/Conductor.gd
+++ b/Scripts/Conductor.gd
@@ -216,7 +216,7 @@ func _findRank(ratio):
 
 # guess what this fucking does
 func _quit():
-	get_tree().change_scene_to_file("res://Scenes/main.tscn")
+	SceneTransitions.change_scene(global.prevScene)
 
 
 # -------------------------

--- a/Scripts/Controller.gd
+++ b/Scripts/Controller.gd
@@ -93,4 +93,8 @@ func _level():
 	get_tree().change_scene_to_file("res://Scenes/PlayGame.tscn")
 
 func _settings():
+	global.prevScene = get_tree().current_scene.scene_file_path
 	get_tree().change_scene_to_file("res://Scenes/Settings.tscn")
+
+func _back():
+	get_tree().change_scene_to_file("res://Scenes/MainMenu.tscn")

--- a/Scripts/Controller.gd
+++ b/Scripts/Controller.gd
@@ -90,11 +90,12 @@ func _findRank(ratio):
 
 # if you do not know what these do you are a lost cause :D
 func _level():
-	get_tree().change_scene_to_file("res://Scenes/PlayGame.tscn")
+	global.prevScene = get_tree().current_scene.scene_file_path
+	SceneTransitions.change_scene("res://Scenes/PlayGame.tscn")
 
 func _settings():
 	global.prevScene = get_tree().current_scene.scene_file_path
-	get_tree().change_scene_to_file("res://Scenes/Settings.tscn")
+	SceneTransitions.change_scene("res://Scenes/Settings.tscn")
 
 func _back():
-	get_tree().change_scene_to_file("res://Scenes/MainMenu.tscn")
+	SceneTransitions.change_scene("res://Scenes/MainMenu.tscn")

--- a/Scripts/MainMenu.gd
+++ b/Scripts/MainMenu.gd
@@ -1,0 +1,27 @@
+extends Node2D
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	
+	# TODO: have an animation for developer
+	global.prevScene = get_tree().current_scene.scene_file_path
+	
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass
+
+func _settings():
+	get_tree().change_scene_to_file("res://Scenes/Settings.tscn")
+
+func _freePlay():
+	get_tree().change_scene_to_file("res://Scenes/LevelSelect.tscn")
+	
+func _storyMode():
+	pass
+
+func _chartEditor():
+	pass

--- a/Scripts/MainMenu.gd
+++ b/Scripts/MainMenu.gd
@@ -14,14 +14,20 @@ func _ready():
 func _process(delta):
 	pass
 
-func _settings():
-	get_tree().change_scene_to_file("res://Scenes/Settings.tscn")
-
-func _freePlay():
-	get_tree().change_scene_to_file("res://Scenes/LevelSelect.tscn")
-	
 func _storyMode():
 	pass
-
+	
+func _freePlay():
+	SceneTransitions.change_scene("res://Scenes/LevelSelect.tscn")
+	
 func _chartEditor():
 	pass
+
+func _settings():
+	SceneTransitions.change_scene("res://Scenes/Settings.tscn")
+
+
+	
+
+
+

--- a/Scripts/SceneTransitions.gd
+++ b/Scripts/SceneTransitions.gd
@@ -1,0 +1,7 @@
+extends CanvasLayer
+
+func change_scene(newScene: String):
+	$AnimationPlayer.play("disolve")
+	await $AnimationPlayer.animation_finished
+	get_tree().change_scene_to_file(newScene)
+	$AnimationPlayer.play_backwards("disolve")

--- a/Scripts/Settings.gd
+++ b/Scripts/Settings.gd
@@ -41,7 +41,7 @@ func _unhandled_input(event):
 
 # fucking guess what this do
 func _back():
-	get_tree().change_scene_to_file("res://Scenes/main.tscn")
+	get_tree().change_scene_to_file(global.prevScene)
 
 func _setKey(key):
 	selectedKey = key

--- a/Scripts/Settings.gd
+++ b/Scripts/Settings.gd
@@ -41,7 +41,7 @@ func _unhandled_input(event):
 
 # fucking guess what this do
 func _back():
-	get_tree().change_scene_to_file(global.prevScene)
+	SceneTransitions.change_scene(global.prevScene)
 
 func _setKey(key):
 	selectedKey = key

--- a/Scripts/global.gd
+++ b/Scripts/global.gd
@@ -114,6 +114,9 @@ var hitregcolors = [
 	0x200000FF,
 ]
 
+# store the previous scene for back button functionality
+var prevScene = null;
+
 func _ready():
 	# Set whether or not we playing on web
 	osvers = OS.get_name() == "Web"

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Beats of Mind"
-run/main_scene="res://Scenes/main.tscn"
+run/main_scene="res://Scenes/MainMenu.tscn"
 config/features=PackedStringArray("4.1", "GL Compatibility")
 run/max_fps=150
 config/icon="res://Assets/icon.svg"

--- a/project.godot
+++ b/project.godot
@@ -19,6 +19,7 @@ config/icon="res://Assets/icon.svg"
 [autoload]
 
 global="*res://Scripts/global.gd"
+SceneTransitions="*res://Scenes/SceneTransitions.tscn"
 
 [display]
 


### PR DESCRIPTION
Added a main menu with future functionality for both the story mode map and the chart editor, as well as currently supported features (free play levels and settings).

Added simple transitions between scenes to make UX smoother. Done in a way that allows for easy updates in future for better transitions